### PR TITLE
Prevent NumberFormatException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/com/redhat/maven/index/checker/MavenIndexChecker.java
+++ b/src/main/java/com/redhat/maven/index/checker/MavenIndexChecker.java
@@ -45,7 +45,7 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
-import org.json.simple.JSONArray;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.commons.cli.*;
@@ -392,10 +392,15 @@ public class MavenIndexChecker {
                         System.out.print(",");
                     }
                     notFirst = true;
-                    OutputInfo oi = new OutputInfo(cursor.getString("groupId"),
-                                                   cursor.getString("artifactId"),
-                                                   cursor.getString("version"));
-                    System.out.print(oi.toJSON());
+
+                    try {
+                        OutputInfo oi = new OutputInfo(cursor.getString("groupId"),
+                                                       cursor.getString("artifactId"),
+                                                       cursor.getString("version"));
+                        System.out.print(oi.toJSON());
+                    } catch (SqlJetException | NumberFormatException ex) {
+                        logger.error("Failed to fetch data from database", ex);
+                    }
                     cursor.next();
                 }
             } finally {


### PR DESCRIPTION
Exception in thread "main" java.lang.NumberFormatException: For input string: "6909e38"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:589)
	at java.lang.Long.valueOf(Long.java:803)
	at org.tmatesoft.sqljet.core.internal.SqlJetUtility.atoi64(SqlJetUtility.java:927)
	at org.tmatesoft.sqljet.core.internal.vdbe.SqlJetVdbeMem.applyNumericAffinity(SqlJetVdbeMem.java:1220)
	at org.tmatesoft.sqljet.core.internal.vdbe.SqlJetVdbeMem.applyAffinity(SqlJetVdbeMem.java:1195)
	at org.tmatesoft.sqljet.core.internal.table.SqlJetBtreeDataTable.getValueMem(SqlJetBtreeDataTable.java:1071)
	at org.tmatesoft.sqljet.core.internal.table.SqlJetBtreeTable.getString(SqlJetBtreeTable.java:389)
	at org.tmatesoft.sqljet.core.internal.table.SqlJetTableDataCursor$5.run(SqlJetTableDataCursor.java:108)
	at org.tmatesoft.sqljet.core.table.SqlJetDb$3.run(SqlJetDb.java:240)
	at org.tmatesoft.sqljet.core.table.engine.SqlJetEngine$12.runSynchronized(SqlJetEngine.java:533)
	at org.tmatesoft.sqljet.core.table.engine.SqlJetEngine.runSynchronized(SqlJetEngine.java:217)
	at org.tmatesoft.sqljet.core.table.engine.SqlJetEngine.runEngineTransaction(SqlJetEngine.java:529)
	at org.tmatesoft.sqljet.core.table.SqlJetDb.runTransaction(SqlJetDb.java:238)
	at org.tmatesoft.sqljet.core.table.SqlJetDb.runReadTransaction(SqlJetDb.java:225)
	at org.tmatesoft.sqljet.core.internal.table.SqlJetTableDataCursor.getString(SqlJetTableDataCursor.java:106)
	at com.redhat.maven.index.checker.MavenIndexChecker.perform(MavenIndexChecker.java:397)
at com.redhat.maven.index.checker.MavenIndexChecker.main(MavenIndexChecker.java:142)