### PR TITLE
fix: Central Repository support for secure HTTP

### DIFF
--- a/src/main/java/com/redhat/maven/index/checker/MavenIndexChecker.java
+++ b/src/main/java/com/redhat/maven/index/checker/MavenIndexChecker.java
@@ -178,7 +178,7 @@ public class MavenIndexChecker {
 
     private final Logger logger;
 
-    private final static String MAVEN_URL = "http://repo1.maven.org/maven2";
+    private final static String MAVEN_URL = "https://repo1.maven.org/maven2";
 
     private int maxJarNumber = -1;
 


### PR DESCRIPTION
# Description

Fix maven dependencies are failing with a 501 error as it no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.